### PR TITLE
fixed README and main.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ EXAMPLE
 -------
 ```hcl
 module "dcos-iam" {
-  source  = "terraform-dcos/iam/aws"
+  source  = "dcos-terraform/iam/aws"
   version = "~> 0.1"
 
   cluster_name = "production"

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@
  * -------
  * ```hcl
  * module "dcos-iam" {
- *   source  = "terraform-dcos/iam/aws"
+ *   source  = "dcos-terraform/iam/aws"
  *   version = "~> 0.1"
  *
  *   cluster_name = "production"


### PR DESCRIPTION
modified a typo in the README and the example hcl in the main.tf to reflect the correct source on the terraform registry. This will fix issue of:

Error downloading modules: Error loading modules: module terraform-dcos/iam/aws not found