### PR TITLE
Dynamic Masters POC

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ EXAMPLE
 ```hcl
 module "dcos-iam" {
   source  = "dcos-terraform/iam/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "production"
 }
@@ -20,6 +20,7 @@ module "dcos-iam" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| aws_s3_bucket | S3 Bucket for External Exhibitor | string | `` | no |
 | cluster_name | Name of the DC/OS cluster | string | - | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  * ```hcl
  * module "dcos-iam" {
  *   source  = "dcos-terraform/iam/aws"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   cluster_name = "production"
  * }
@@ -180,6 +180,25 @@ resource "aws_iam_role_policy" "master_policy" {
 {
     "Version": "2012-10-17",
     "Statement": [
+      {
+          "Sid": "DCOSExternalExhibitorBucketLevel",
+          "Effect": "Allow",
+          "Action": [
+              "s3:ListBucket"
+          ],
+          "Resource": "arn:aws:s3:::${coalesce(var.aws_s3_bucket, "soak-cluster-logs")}"
+      },
+      {
+          "Sid": "DCOSExternalExhibitorObjectLevel",
+          "Effect": "Allow",
+          "Action": [
+              "s3:PutObject",
+              "s3:GetObject",
+              "s3:DeleteObject"
+              
+          ],
+          "Resource": "arn:aws:s3:::${coalesce(var.aws_s3_bucket, "soak-cluster-logs")}/*"
+      },
       {
           "Sid": "SoakClusterLogsArchiveBucketLevel",
           "Effect": "Allow",

--- a/main.tf
+++ b/main.tf
@@ -173,8 +173,9 @@ resource "aws_iam_instance_profile" "master_profile" {
 }
 
 resource "aws_iam_role_policy" "master_policy" {
-  name = "dcos-${var.cluster_name}-master_instance_policy"
-  role = "${aws_iam_role.master_role.id}"
+  count = "${var.aws_s3_bucket != "" ? 1 : 0}"
+  name  = "dcos-${var.cluster_name}-master_instance_policy"
+  role  = "${aws_iam_role.master_role.id}"
 
   policy = <<EOF
 {
@@ -186,7 +187,7 @@ resource "aws_iam_role_policy" "master_policy" {
           "Action": [
               "s3:ListBucket"
           ],
-          "Resource": "arn:aws:s3:::${coalesce(var.aws_s3_bucket, "soak-cluster-logs")}"
+          "Resource": "arn:aws:s3:::${var.aws_s3_bucket}"
       },
       {
           "Sid": "DCOSExternalExhibitorObjectLevel",
@@ -197,30 +198,7 @@ resource "aws_iam_role_policy" "master_policy" {
               "s3:DeleteObject"
               
           ],
-          "Resource": "arn:aws:s3:::${coalesce(var.aws_s3_bucket, "soak-cluster-logs")}/*"
-      },
-      {
-          "Sid": "SoakClusterLogsArchiveBucketLevel",
-          "Effect": "Allow",
-          "Action": [
-              "s3:ListBucket"
-          ],
-          "Resource": "arn:aws:s3:::soak-cluster-logs"
-      },
-      {
-          "Sid": "SoakClusterLogsArchiveObjectLevel",
-          "Effect": "Allow",
-          "Action": [
-              "s3:PutObject"
-          ],
-          "Resource": "arn:aws:s3:::soak-cluster-logs/*"
-      },
-      {
-          "Effect": "Allow",
-          "Action": [
-              "es:*"
-          ],
-          "Resource": "arn:aws:es:us-east-1:159577368695:domain/scaletestlogsinkpublic/*"
+          "Resource": "arn:aws:s3:::${var.aws_s3_bucket}/*"
       }
     ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
 variable "cluster_name" {
   description = "Name of the DC/OS cluster"
 }
+
+variable "aws_s3_bucket" {
+  description = "S3 Bucket for External Exhibitor"
+  default     = ""
+}


### PR DESCRIPTION
Adding a new Policy for the Masters that will allow it to have appropriate permissions to write to a specified S3 Bucket for external ZK. If there is no variable specified it will fallback to the default bucket of 'soak-cluster-logs' which is not actually created or does it exist. We could always change this if desired in the future. 